### PR TITLE
Fixes to end-to-end tests

### DIFF
--- a/flytetester/Makefile
+++ b/flytetester/Makefile
@@ -20,7 +20,7 @@ register_staging: docker_push
 	-e FLYTE_CREDENTIALS_CLIENT_SECRET=${FLYTE_CREDENTIALS_CLIENT_SECRET} \
 	-e FLYTE_CREDENTIALS_AUTH_MODE=basic -e FLYTE_CREDENTIALS_AUTHORIZATION_METADATA_KEY=flyte-authorization \
 	-e FLYTE_CREDENTIALS_SCOPE=svc -e FLYTE_PLATFORM_AUTH=True \
-	ghcr.io/nuclyde-io/${IMAGE_NAME}:${VERSION} /usr/local/bin/flytekit_venv make register_staging_in_container
+	ghcr.io/flyteorg/${IMAGE_NAME}:${VERSION} /usr/local/bin/flytekit_venv make register_staging_in_container
 
 .PHONY: register_production_in_container
 register_production_in_container:
@@ -32,7 +32,7 @@ register_production: docker_push
 	-e FLYTE_CREDENTIALS_CLIENT_SECRET=${FLYTE_CREDENTIALS_CLIENT_SECRET} \
 	-e FLYTE_CREDENTIALS_AUTH_MODE=basic -e FLYTE_CREDENTIALS_AUTHORIZATION_METADATA_KEY=flyte-authorization \
 	-e FLYTE_CREDENTIALS_SCOPE=svc -e FLYTE_PLATFORM_AUTH=True \
-	ghcr.io/nuclyde-io/${IMAGE_NAME}:${VERSION} /usr/local/bin/flytekit_venv make register_production_in_container
+	ghcr.io/flyteorg/${IMAGE_NAME}:${VERSION} /usr/local/bin/flytekit_venv make register_production_in_container
 
 .PHONY: register_production_in_container
 register_sandbox_in_container:
@@ -40,7 +40,7 @@ register_sandbox_in_container:
 
 .PHONY: register_sandbox
 register_sandbox: docker_push
-	docker run ghcr.io/nuclyde-io/${IMAGE_NAME}:${VERSION} /usr/local/bin/flytekit_venv make register_sandbox_in_container
+	docker run ghcr.io/flyteorg/${IMAGE_NAME}:${VERSION} /usr/local/bin/flytekit_venv make register_sandbox_in_container
 
 .PHONY: end2end
 end2end_test:
@@ -52,7 +52,7 @@ docker_build:
 
 .PHONY: docker_push
 docker_push:
-	REGISTRY=ghcr.io/nuclyde-io scripts/docker_build.sh
+	REGISTRY=ghcr.io/flyteorg scripts/docker_build.sh
 
 .PHONY: docker_build_push
 docker_build_push:

--- a/flytetester/end2end/validator.py
+++ b/flytetester/end2end/validator.py
@@ -151,9 +151,10 @@ def retrys_dynamic_wf_validator(execution, node_execution_list, task_execution_l
         elif phase == _WorkflowExecutionPhase.RUNNING or phase == _WorkflowExecutionPhase.UNDEFINED:
             return None  # come back and check later
         else:
+            print(f'FailingDynamicNodeWF got unexpected phase [{phase}]')
             return False
 
-    print('FailingDynamicNodeWF finished with {} task(s)'.format(len(task_execution_list)))
+    print(f'FailingDynamicNodeWF finished with {len(task_execution_list)} task(s), expected 3')
     assert len(task_execution_list) == 3
     print('Done validating app.workflows.failing_workflows.FailingDynamicNodeWF!')
     return True

--- a/flytetester/end2end/validator.py
+++ b/flytetester/end2end/validator.py
@@ -148,7 +148,8 @@ def retrys_dynamic_wf_validator(execution, node_execution_list, task_execution_l
                 phase == _WorkflowExecutionPhase.TIMED_OUT:
             print(f'Error with app.workflows.failing_workflows.FailingDynamicNodeWF, phase is {phase}')
             return False
-        elif phase == _WorkflowExecutionPhase.RUNNING or phase == _WorkflowExecutionPhase.UNDEFINED:
+        elif phase == _WorkflowExecutionPhase.RUNNING or phase == _WorkflowExecutionPhase.UNDEFINED or \
+                phase == _WorkflowExecutionPhase.FAILING:
             return None  # come back and check later
         else:
             print(f'FailingDynamicNodeWF got unexpected phase [{phase}]')

--- a/flytetester/end2end/validator.py
+++ b/flytetester/end2end/validator.py
@@ -148,7 +148,7 @@ def retrys_dynamic_wf_validator(execution, node_execution_list, task_execution_l
                 phase == _WorkflowExecutionPhase.TIMED_OUT:
             print(f'Error with app.workflows.failing_workflows.FailingDynamicNodeWF, phase is {phase}')
             return False
-        elif phase == _WorkflowExecutionPhase.RUNNING:
+        elif phase == _WorkflowExecutionPhase.RUNNING or phase == _WorkflowExecutionPhase.UNDEFINED:
             return None  # come back and check later
         else:
             return False

--- a/flytetester/end2end/validator.py
+++ b/flytetester/end2end/validator.py
@@ -120,10 +120,12 @@ def retrys_wf_validator(execution, node_execution_list, task_execution_list):
         # If not failed, fail the test if the execution is in an unacceptable state
         if phase == _WorkflowExecutionPhase.ABORTED or phase == _WorkflowExecutionPhase.SUCCEEDED or \
                 phase == _WorkflowExecutionPhase.TIMED_OUT:
+            print(f'Error with app.workflows.failing_workflows.RetrysWf, phase is {phase}')
             return False
         else:
             return None  # come back and check later
 
+    print(f"Finished RetrysWf: execution length is {len(task_execution_list)}, should be 3")
     assert len(task_execution_list) == 3
     print('Done validating app.workflows.failing_workflows.RetrysWf!')
     return True
@@ -144,6 +146,7 @@ def retrys_dynamic_wf_validator(execution, node_execution_list, task_execution_l
         # If not failed, fail the test if the execution is in an unacceptable state
         if phase == _WorkflowExecutionPhase.ABORTED or phase == _WorkflowExecutionPhase.SUCCEEDED or \
                 phase == _WorkflowExecutionPhase.TIMED_OUT:
+            print(f'Error with app.workflows.failing_workflows.FailingDynamicNodeWF, phase is {phase}')
             return False
         elif phase == _WorkflowExecutionPhase.RUNNING:
             return None  # come back and check later

--- a/flytetester/end2end/validator.py
+++ b/flytetester/end2end/validator.py
@@ -11,7 +11,6 @@ from flytekit.configuration.platform import URL, INSECURE
 from flytekit.models.core.execution import WorkflowExecutionPhase as _WorkflowExecutionPhase
 from flytekit.models.admin.common import Sort
 
-
 PROJECT = 'flytetester'
 DOMAIN = 'development'
 
@@ -28,6 +27,7 @@ EXPECTED_EXECUTIONS = [
 # This tells Python where admin is, and also to hit Minio instead of the real S3
 update_configuration_file('end2end/end2end.config')
 client = SynchronousFlyteClient(URL.get(), insecure=INSECURE.get())
+
 
 # For every workflow that we test on in run.sh, have a function that can validate the execution response
 # It will be supplied an execution object, a node execution list, and a task execution list
@@ -174,11 +174,13 @@ def run_to_completion_wf_validator(execution, node_execution_list, task_executio
         # If not failed, fail the test if the execution is in an unacceptable state
         if phase == _WorkflowExecutionPhase.ABORTED or phase == _WorkflowExecutionPhase.SUCCEEDED or \
                 phase == _WorkflowExecutionPhase.TIMED_OUT:
+            print('RunToCompletionWF got incorrect phase [{}]'.format(phase))
             return False
-        elif phase == _WorkflowExecutionPhase.RUNNING or phase == _WorkflowExecutionPhase.FAILING:
+        elif phase == _WorkflowExecutionPhase.RUNNING or phase == _WorkflowExecutionPhase.FAILING or \
+                phase == _WorkflowExecutionPhase.UNDEFINED:
             return None  # come back and check later
         else:
-            print('Got unexpected phase [{}]'.format(phase))
+            print('RunToCompletionWF got unexpected phase [{}]'.format(phase))
             return False
 
     print('RunToCompletionWF finished with {} task(s)'.format(len(task_execution_list)))


### PR DESCRIPTION
* With the new propeller changes, the initial phase was coming back as `0` so add that to the workflows that check for it so that it doesn't fail.
* Better retrieval of executions so that it doesn't rely on a completely empty database.  This makes it so that you can just create the pod on a cluster and don't have to deal with dockernetes.
* Use ghcr.io/flyteorg as the image org