### PR TITLE
Use flytectl

### DIFF
--- a/flytetester/Dockerfile
+++ b/flytetester/Dockerfile
@@ -48,5 +48,5 @@ ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"
 RUN mkdir /opt/go
 WORKDIR /opt/go
 RUN curl -s https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | bash
-WORKDIR /root
 ENV PATH="/opt/go/bin:$PATH"
+WORKDIR /root

--- a/flytetester/Dockerfile
+++ b/flytetester/Dockerfile
@@ -49,3 +49,4 @@ RUN mkdir /opt/go
 WORKDIR /opt/go
 RUN curl -s https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | bash
 WORKDIR /root
+ENV PATH="/opt/go/bin:$PATH"

--- a/flytetester/Dockerfile
+++ b/flytetester/Dockerfile
@@ -44,3 +44,8 @@ ARG DOCKER_IMAGE
 # This tag is supplied by the build script and will be used to determine the version
 # when registering tasks, workflows, and launch plans
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"
+
+RUN mkdir /opt/go
+WORKDIR /opt/go
+RUN curl -s https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | bash
+WORKDIR /root

--- a/flytetester/Dockerfile
+++ b/flytetester/Dockerfile
@@ -29,6 +29,15 @@ RUN ${VENV}/bin/pip install wheel
 COPY ./requirements.txt /root
 RUN ${VENV}/bin/pip install -r /root/requirements.txt
 
+# Flytectl installation
+RUN mkdir /opt/go
+# This will be removed once flytectl respects command line settings
+COPY ./end2end/config.yaml /opt/go
+WORKDIR /opt/go
+RUN curl -s https://raw.githubusercontent.com/flyteorg/flytectl/v0.1.2/install.sh | bash
+ENV PATH="/opt/go/bin:$PATH"
+WORKDIR /root
+
 # Copy the actual code
 COPY . /root
 
@@ -44,10 +53,3 @@ ARG DOCKER_IMAGE
 # This tag is supplied by the build script and will be used to determine the version
 # when registering tasks, workflows, and launch plans
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"
-
-RUN mkdir /opt/go
-COPY ./end2end/config.yaml /opt/go
-WORKDIR /opt/go
-RUN curl -s https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | bash
-ENV PATH="/opt/go/bin:$PATH"
-WORKDIR /root

--- a/flytetester/Dockerfile
+++ b/flytetester/Dockerfile
@@ -46,6 +46,7 @@ ARG DOCKER_IMAGE
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"
 
 RUN mkdir /opt/go
+COPY ./end2end/config.yaml /opt/go
 WORKDIR /opt/go
 RUN curl -s https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | bash
 ENV PATH="/opt/go/bin:$PATH"

--- a/flytetester/end2end/config.yaml
+++ b/flytetester/end2end/config.yaml
@@ -1,0 +1,6 @@
+admin:
+  endpoint: flyteadmin:81
+  insecure: true
+logger:
+  show-source: true
+  level: 1

--- a/flytetester/end2end/run.sh
+++ b/flytetester/end2end/run.sh
@@ -20,20 +20,20 @@ arrIN=(${FLYTE_INTERNAL_IMAGE//:/ })
 VERSION=${arrIN[1]}
 
 #flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.DivideByZeroWf
-flytectl get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile DivideByZeroWf.yaml
-flytectl create execution --execFile DivideByZeroWf.yaml -p flytetester -d development
+flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile DivideByZeroWf.yaml
+flytectl --config /opt/go/config.yaml create execution --execFile DivideByZeroWf.yaml -p flytetester -d development
 
 #flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RetrysWf
-flytectl get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile Retrys.yaml
-flytectl create execution --execFile Retrys.yaml -p flytetester -d development
+flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile Retrys.yaml
+flytectl --config /opt/go/config.yaml create execution --execFile Retrys.yaml -p flytetester -d development
 
 #flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.FailingDynamicNodeWF
-flytectl get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile FailingDynamicNodeWF.yaml
-flytectl create execution --execFile FailingDynamicNodeWF.yaml -p flytetester -d development
+flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile FailingDynamicNodeWF.yaml
+flytectl --config /opt/go/config.yaml create execution --execFile FailingDynamicNodeWF.yaml -p flytetester -d development
 
 #flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RunToCompletionWF
-flytectl get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile RunToCompletionWF.yaml
-flytectl create execution --execFile RunToCompletionWF.yaml -p flytetester -d development
+flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile RunToCompletionWF.yaml
+flytectl --config /opt/go/config.yaml create execution --execFile RunToCompletionWF.yaml -p flytetester -d development
 
 # Make sure workflow does everything correctly
 flytekit_venv python end2end/validator.py

--- a/flytetester/end2end/run.sh
+++ b/flytetester/end2end/run.sh
@@ -19,19 +19,15 @@ flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development
 arrIN=(${FLYTE_INTERNAL_IMAGE//:/ })
 VERSION=${arrIN[1]}
 
-#flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.DivideByZeroWf
 flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.DivideByZeroWf --version ${VERSION} --execFile DivideByZeroWf.yaml
 flytectl --config /opt/go/config.yaml create execution --execFile DivideByZeroWf.yaml -p flytetester -d development
 
-#flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RetrysWf
 flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile Retrys.yaml
 flytectl --config /opt/go/config.yaml create execution --execFile Retrys.yaml -p flytetester -d development
 
-#flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.FailingDynamicNodeWF
 flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.FailingDynamicNodeWF --version ${VERSION} --execFile FailingDynamicNodeWF.yaml
 flytectl --config /opt/go/config.yaml create execution --execFile FailingDynamicNodeWF.yaml -p flytetester -d development
 
-#flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RunToCompletionWF
 flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RunToCompletionWF --version ${VERSION} --execFile RunToCompletionWF.yaml
 flytectl --config /opt/go/config.yaml create execution --execFile RunToCompletionWF.yaml -p flytetester -d development
 

--- a/flytetester/end2end/run.sh
+++ b/flytetester/end2end/run.sh
@@ -12,11 +12,28 @@ flytekit_venv flyte-cli -h flyteadmin:81 --insecure register-project -n flytetes
 flytekit_venv pyflyte -c end2end/end2end.config register -p flytetester -d development workflows
 
 # Kick off workflows
+# This one needs an input, which is easier to do programmatically using flytekit
 flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.work.WorkflowWithIO --b hello_world
-flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.DivideByZeroWf
-flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RetrysWf
-flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.FailingDynamicNodeWF
-flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RunToCompletionWF
+
+# Quick shortcut to get at the version
+arrIN=(${FLYTE_INTERNAL_IMAGE//:/ })
+VERSION=${arrIN[1]}
+
+#flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.DivideByZeroWf
+flytectl get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile DivideByZeroWf.yaml
+flytectl create execution --execFile DivideByZeroWf.yaml -p flytetester -d development
+
+#flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RetrysWf
+flytectl get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile Retrys.yaml
+flytectl create execution --execFile Retrys.yaml -p flytetester -d development
+
+#flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.FailingDynamicNodeWF
+flytectl get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile FailingDynamicNodeWF.yaml
+flytectl create execution --execFile FailingDynamicNodeWF.yaml -p flytetester -d development
+
+#flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RunToCompletionWF
+flytectl get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile RunToCompletionWF.yaml
+flytectl create execution --execFile RunToCompletionWF.yaml -p flytetester -d development
 
 # Make sure workflow does everything correctly
 flytekit_venv python end2end/validator.py

--- a/flytetester/end2end/run.sh
+++ b/flytetester/end2end/run.sh
@@ -20,7 +20,7 @@ arrIN=(${FLYTE_INTERNAL_IMAGE//:/ })
 VERSION=${arrIN[1]}
 
 #flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.DivideByZeroWf
-flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile DivideByZeroWf.yaml
+flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.DivideByZeroWf --version ${VERSION} --execFile DivideByZeroWf.yaml
 flytectl --config /opt/go/config.yaml create execution --execFile DivideByZeroWf.yaml -p flytetester -d development
 
 #flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RetrysWf
@@ -28,11 +28,11 @@ flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d developme
 flytectl --config /opt/go/config.yaml create execution --execFile Retrys.yaml -p flytetester -d development
 
 #flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.FailingDynamicNodeWF
-flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile FailingDynamicNodeWF.yaml
+flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.FailingDynamicNodeWF --version ${VERSION} --execFile FailingDynamicNodeWF.yaml
 flytectl --config /opt/go/config.yaml create execution --execFile FailingDynamicNodeWF.yaml -p flytetester -d development
 
 #flytekit_venv pyflyte -c end2end/end2end.config lp -p flytetester -d development execute app.workflows.failing_workflows.RunToCompletionWF
-flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RetrysWf --version ${VERSION} --execFile RunToCompletionWF.yaml
+flytectl --config /opt/go/config.yaml get launchplan -p flytetester -d development app.workflows.failing_workflows.RunToCompletionWF --version ${VERSION} --execFile RunToCompletionWF.yaml
 flytectl --config /opt/go/config.yaml create execution --execFile RunToCompletionWF.yaml -p flytetester -d development
 
 # Make sure workflow does everything correctly

--- a/flytetester/end2end/validator.py
+++ b/flytetester/end2end/validator.py
@@ -205,7 +205,7 @@ def process_executions(execution_names):
     This is the main loop of the end to end test.  Basically it's an infinite loop, that only exits if everything
     has finished (either successfully or unsuccessfully), pausing for five seconds at a time.
 
-    For each executionthe list of expected executions given in the input, it will query the Admin service for
+    For each execution in the list of expected executions given in the input, it will query the Admin service for
     the execution object, all node executions, and all task executions, and hand these objects off to the validator
     function for the respective workflow.
 

--- a/flytetester/end2end/validator.py
+++ b/flytetester/end2end/validator.py
@@ -205,7 +205,7 @@ def process_executions(execution_names):
     This is the main loop of the end to end test.  Basically it's an infinite loop, that only exits if everything
     has finished (either successfully or unsuccessfully), pausing for five seconds at a time.
 
-    For each execution in the list of expected executions given in the input, it will query the Admin service for
+    For each executionthe list of expected executions given in the input, it will query the Admin service for
     the execution object, all node executions, and all task executions, and hand these objects off to the validator
     function for the respective workflow.
 


### PR DESCRIPTION
Now that flytectl is in a more stable place, use it instead to launch executions.

Currently we need a config.yaml file - command line args are not yet respected.  There's an open PR for this - https://github.com/flyteorg/flytestdlib/pull/69.

