### PR TITLE
Remove create project from the test script

### DIFF
--- a/flytetester/end2end/run.sh
+++ b/flytetester/end2end/run.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Create the project name since this is not one of the defaults
-flytekit_venv flyte-cli -h flyteadmin:81 --insecure register-project -n flytetester --identifier flytetester -d "test_project" || true
-
 ### Need to get Flyte Admin to cluster sync this so that k8s resources are actually created ###
 # Currently, kill the admin pod, so that the init container sync picks up the change.
 


### PR DESCRIPTION
After migrating from kind to sandbox, we don't need to create project, Sandbox already has it. Currently, it is throwing an error because of this https://github.com/flyteorg/flytepropeller/runs/3998138465?check_suite_focus=true#step:8:3856


Fix: https://github.com/flyteorg/flyte/issues/1474