### PR TITLE
Run functional tests script

### DIFF
--- a/flytetester/Dockerfile
+++ b/flytetester/Dockerfile
@@ -13,7 +13,7 @@ RUN : \
 
 RUN : \
     && apt-get update \
-    && apt-get install -y python3.8 python3-pip python3-venv make build-essential libssl-dev curl vim
+    && apt-get install -y python3.8 python3-pip python3-venv make build-essential libssl-dev curl vim jq
 
 # This is necessary for opencv to work
 RUN apt-get update && apt-get install -y libsm6 libxext6 libxrender-dev ffmpeg

--- a/flytetester/Makefile
+++ b/flytetester/Makefile
@@ -46,6 +46,10 @@ register_sandbox: docker_push
 end2end_test:
 	flytekit_venv end2end/run.sh
 
+.PHONY: functional_test
+functional_test:
+	flytekit_venv functional-tests/run.sh
+
 .PHONY: docker_build
 docker_build:
 	scripts/docker_build.sh

--- a/flytetester/end2end/config.yaml
+++ b/flytetester/end2end/config.yaml
@@ -1,5 +1,5 @@
 admin:
-  endpoint: flyteadmin:81
+  endpoint: localhost:30081
   insecure: true
 logger:
   show-source: true

--- a/flytetester/end2end/config.yaml
+++ b/flytetester/end2end/config.yaml
@@ -1,5 +1,5 @@
 admin:
-  endpoint: localhost:30081
+  endpoint: flyteadmin:81
   insecure: true
 logger:
   show-source: true

--- a/flytetester/functional-tests/functional-test.config
+++ b/flytetester/functional-tests/functional-test.config
@@ -1,3 +1,3 @@
 [platform]
-url=localhost:30081
+url=flyteadmin:81
 insecure=True

--- a/flytetester/functional-tests/functional-test.config
+++ b/flytetester/functional-tests/functional-test.config
@@ -1,0 +1,3 @@
+[platform]
+url=flyteadmin:81
+insecure=True

--- a/flytetester/functional-tests/functional-test.config
+++ b/flytetester/functional-tests/functional-test.config
@@ -1,3 +1,3 @@
 [platform]
-url=flyteadmin:81
+url=localhost:30081
 insecure=True

--- a/flytetester/functional-tests/run-tests.py
+++ b/flytetester/functional-tests/run-tests.py
@@ -18,7 +18,37 @@ MAX_ATTEMPTS = 60
 # starting with "core".
 FLYTESNACKS_WORKFLOW_GROUPS: Mapping[str, List[Tuple[str, dict]]] = {
     "core": [
+        ("core.control_flow.chain_tasks.chain_tasks_wf", {}),
+        ("core.control_flow.dynamics.wf", {"s1": "Pear", "s2": "Earth"}),
+        ("core.control_flow.map_task.my_map_workflow", {"a": [1, 2, 3, 4, 5]}),
+        # Workflows that use nested executions cannot be launched via flyteremote.
+        # This issue is being tracked in https://github.com/flyteorg/flyte/issues/1482.
+        # ("core.control_flow.run_conditions.multiplier", {"my_input": 0.5}),
+        # ("core.control_flow.run_conditions.multiplier_2", {"my_input": 10}),
+        # ("core.control_flow.run_conditions.multiplier_3", {"my_input": 5}),
+        # ("core.control_flow.run_conditions.basic_boolean_wf", {"seed": 5}),
+        # ("core.control_flow.run_conditions.bool_input_wf", {"b": True}),
+        # ("core.control_flow.run_conditions.nested_conditions", {"my_input": 0.4}),
+        # ("core.control_flow.run_conditions.consume_outputs", {"my_input": 0.4, "seed": 7}),
+        # ("core.control_flow.run_merge_sort.merge_sort", {"numbers": [5, 4, 3, 2, 1], "count": 5}),
+        ("core.control_flow.subworkflows.parent_wf", {"a": 3}),
+        ("core.control_flow.subworkflows.nested_parent_wf", {"a": 3}),
+        ("core.flyte_basics.basic_workflow.my_wf", {"a": 50, "b": "hello"}),
+        # Getting a 403 for the wikipedia image
+        # ("core.flyte_basics.files.rotate_one_workflow", {"in_image": "https://upload.wikimedia.org/wikipedia/commons/d/d2/Julia_set_%28C_%3D_0.285%2C_0.01%29.jpg"}),
+        ("core.flyte_basics.folders.download_and_rotate", {}),
         ("core.flyte_basics.hello_world.my_wf", {}),
+        ("core.flyte_basics.lp.my_wf", {"val": 4}),
+        ("core.flyte_basics.lp.go_greet", {"day_of_week": "5", "number": 3, "am": True}),
+        ("core.flyte_basics.named_outputs.my_wf", {}),
+        # # Getting a 403 for the wikipedia image
+        # # ("core.flyte_basics.reference_task.wf", {}),
+        ("core.type_system.custom_objects.wf", {"x": 10, "y": 20}),
+        # Enums are not supported in flyteremote
+        # ("core.type_system.enums.enum_wf", {"c": "red"}),
+        ("core.type_system.schema.df_wf", {"a": 42}),
+        ("core.type_system.typed_schema.wf", {}),
+        ("my.imperative.workflow.example", {"in1": "hello", "in2": "foo"}),
     ],
 }
 

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -4,6 +4,9 @@ set -ex
 
 LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 
+# TODO: Leave this here while we don't have a new flytesnacks release, let's use a release that is not affected by the conditional bug.
+LATEST_VERSION=v0.3.27
+
 # We register the workflows here to avoid a race condition between registering the latest version of flytesnacks and the execution of the functional tests.
 # flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
 

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -8,6 +8,6 @@ set -ex
 LATEST_VERSION=v0.3.27
 
 # We register the workflows here to avoid a race condition between registering the latest version of flytesnacks and the execution of the functional tests.
-flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
+# flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
 
 flytekit_venv python functional-tests/run-tests.py $LATEST_VERSION P0,P1 functional-tests/functional-test.config core

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -4,4 +4,6 @@ set -ex
 
 LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 
+flytectl register examples -p flytesnacks -d development --config /opt/go/config.yaml
+
 flytekit_venv python functional-tests/run-tests.py $LATEST_VERSION P0,P1 functional-tests/functional-test.config core

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -2,9 +2,9 @@
 
 set -ex
 
-LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 
 # TODO: Leave this here while we don't have a new flytesnacks release, let's use a release that is not affected by the conditional bug.
+# LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 LATEST_VERSION=v0.3.27
 
 # We register the workflows here to avoid a race condition between registering the latest version of flytesnacks and the execution of the functional tests.

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -5,6 +5,6 @@ set -ex
 
 # TODO: Leave this here while we don't have a new flytesnacks release, let's use a release that is not affected by the conditional bug.
 # LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
-LATEST_VERSION=v0.3.27
+LATEST_VERSION=v0.1.1
 
 flytekit_venv python functional-tests/run-tests.py $LATEST_VERSION P0,P1 functional-tests/functional-test.config core

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -7,7 +7,4 @@ set -ex
 # LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 LATEST_VERSION=v0.3.27
 
-# We register the workflows here to avoid a race condition between registering the latest version of flytesnacks and the execution of the functional tests.
-# flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
-
 flytekit_venv python functional-tests/run-tests.py $LATEST_VERSION P0,P1 functional-tests/functional-test.config core

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
+
+# We register the workflows here to avoid a race condition between registering the latest version of flytesnacks and the execution of the functional tests.
+flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
+
+flytekit_venv python functional-tests/run-tests.py $LATEST_VERSION P0,P1 functional-tests/functional-test.config core

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -8,6 +8,6 @@ LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnack
 LATEST_VERSION=v0.3.27
 
 # We register the workflows here to avoid a race condition between registering the latest version of flytesnacks and the execution of the functional tests.
-# flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
+flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
 
 flytekit_venv python functional-tests/run-tests.py $LATEST_VERSION P0,P1 functional-tests/functional-test.config core

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-
-# TODO: Leave this here while we don't have a new flytesnacks release, let's use a release that is not affected by the conditional bug.
-# LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
-LATEST_VERSION=v0.1.1
+LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 
 flytekit_venv python functional-tests/run-tests.py $LATEST_VERSION P0,P1 functional-tests/functional-test.config core

--- a/flytetester/functional-tests/run.sh
+++ b/flytetester/functional-tests/run.sh
@@ -5,6 +5,6 @@ set -ex
 LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 
 # We register the workflows here to avoid a race condition between registering the latest version of flytesnacks and the execution of the functional tests.
-flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
+# flytectl register examples -p flytesnacks -d development --version $LATEST_VERSION
 
 flytekit_venv python functional-tests/run-tests.py $LATEST_VERSION P0,P1 functional-tests/functional-test.config core

--- a/flytetester/requirements.txt
+++ b/flytetester/requirements.txt
@@ -1,4 +1,4 @@
-flytekit[sidecar,schema]==0.30.0b10
+flytekit[sidecar,schema]==0.30.0
 statsd
 opencv-python
 k8s-proto>=0.0.2

--- a/flytetester/requirements.txt
+++ b/flytetester/requirements.txt
@@ -1,4 +1,4 @@
-flytekit[sidecar,schema]==0.26.0
+flytekit[sidecar,schema]==0.30.0b10
 statsd
 opencv-python
 k8s-proto>=0.0.2


### PR DESCRIPTION
In this PR we define a new make target to run the functional tests. This is needed because we removed the legacy flytekit SDK starting on the the 0.30.0 release.

The idea is to run them inside a pod, similar to how the end-to-end tests are currently running. In the future we'll transition to using reusable workflows to execute these tests.