### PR TITLE
Added option to pass repository name 

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.actor != 'goreleaserbot'
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.bump-version.outputs.tag }}
+      version: ${{ steps.bump_version.outputs.tag }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -24,7 +24,7 @@ jobs:
         id: extract_branch
         run: echo "::set-output name=branch_name::$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}})"
       - name: Bump version and push tag
-        id: bump-version
+        id: bump_version
         uses: anothrNick/github-tag-action@1.34.0
         env:
           GITHUB_TOKEN: ${{ secrets.FLYTE_BOT_PAT }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,16 +1,7 @@
-name: Bump Version
+name: Go Releaser
 
 on:
   workflow_call:
-    inputs:
-      version:
-        description: "Release version"
-        required: true
-        type: string
-      dry_run:
-        description: "Dry Run"
-        required: false
-        type: boolean
     secrets:
       FLYTE_BOT_PAT:
         required: true
@@ -26,20 +17,9 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
-      - name: Dry Run
-        id: extract_command
-        run:|
-          if [[ ${{ inputs.dry_run }} ]]
-          then
-            echo "::set-output name=command::'release'"
-          else
-            echo "::set-output name=command::'--snapshot  --skip-publish'"
-          fi
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
-          args: ${{ steps.extract_command.outputs.command }} --rm-dist
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.FLYTE_BOT_PAT }}
-          GORELEASER_CURRENT_TAG: ${{ inputs.version }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -2,6 +2,15 @@ name: Bump Version
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: "Release version"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry Run"
+        required: false
+        type: boolean
     secrets:
       FLYTE_BOT_PAT:
         required: true
@@ -17,10 +26,20 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+      - name: Dry Run
+        id: extract_command
+        run:|
+          if [[ ${{ inputs.dry_run }} ]]
+          then
+            echo "::set-output name=command::'release'"
+          else
+            echo "::set-output name=command::'--snapshot  --skip-publish'"
+          fi
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: ${{ steps.extract_command.outputs.command }} --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.FLYTE_BOT_PAT }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ on:
         description: "Version of image"
         required: true
         type: string
+      repository:
+        description: "Repository Name"
+        required: false
+        type: string
       push:
         description: "Push to registry"
         required: false
@@ -33,7 +37,7 @@ jobs:
         with:
           username: "${{ secrets.FLYTE_BOT_USERNAME }}"
           password: "${{ secrets.FLYTE_BOT_PAT }}"
-          image_name: ${{ github.repository }}
+          image_name: ${{ inputs.repository }}
           image_tag: latest,${{ github.sha }},${{ inputs.version }}
           push_git_tag: ${{ inputs.push }}
           dockerfile: ${{ inputs.dockerfile }}


### PR DESCRIPTION
- Bug fix in bump version workflow (We are not getting output correctly that cause error)
- Added option to pass repository name in docker publish, In case of flyteadmin we publish two images from single repository that cause issue.

Flyteadmin fix: https://github.com/flyteorg/flyteadmin/pull/343/files#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165L68