### PR TITLE
Fixed docker build for fork repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
           image_name: ${{ github.repository }}
           image_tag: latest,${{ github.sha }},${{ inputs.version }}
           push_git_tag: ${{ inputs.push }}
+          push_image_and_stages: ${{ inputs.push }}
           dockerfile: ${{ inputs.dockerfile }}
           registry: ghcr.io
           build_extra_args: "--compress=true"


### PR DESCRIPTION
by default `push_image_and_stages` images is true, And in that case our docker build will fail because of this in fork repository 

Logs: https://github.com/flyteorg/flyteconsole/runs/5180972709?check_suite_focus=true