### PR TITLE
Install protoc before generating docs

### DIFF
--- a/.github/workflows/go_generate.yml
+++ b/.github/workflows/go_generate.yml
@@ -13,6 +13,7 @@ jobs:
     name: Go Generate
     steps:
       - uses: actions/checkout@v1
+      - uses: arduino/setup-protoc@v1
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.go-version }}


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

https://github.com/flyteorg/flyteidl/runs/5893306364?check_suite_focus=true
https://github.com/marketplace/actions/setup-protoc
 
Error:
```
Try 'rm --help' for more information.
./generate_protos.sh: line 33: protoc: command not found
rm: missing operand
Try 'rm --help' for more information.
./generate_protos.sh: line 40: protoc: command not found
rm: missing operand
Try 'rm --help' for more information.
./generate_protos.sh: line 47: protoc: command not found
rm: missing operand
Try 'rm --help' for more information.
./generate_protos.sh: line 54: protoc: command not found
rm: missing operand
Try 'rm --help' for more information.
./generate_protos.sh: line 61: protoc: command not found
rm: missing operand
Try 'rm --help' for more information.
./generate_protos.sh: line 68: protoc: command not found
```