### PR TITLE
Update codecov action version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FLYTE_BOT_PAT }}
         run: make install && make test_unit_codecov
       - name: Push CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.5.2
         with:
           file: coverage.txt
           flags: unittests


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

Seeing a lot of `Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue` lately which is fixed by upgrading the codecov action (https://github.com/codecov/codecov-action/issues/330)