### PR TITLE
Ignore codecov upload failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           file: coverage.txt
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FLYTE_BOT_PAT }}
         run: make install && make test_unit_codecov
       - name: Push CodeCov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v3.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.FLYTE_BOT_PAT }}        
         with:


### PR DESCRIPTION
This PR allows the github worklow to succeed even if codecov upload fails.

Signed-off-by: Dan Rammer <daniel@union.ai>