### PR TITLE
Login to GitHub registry only when push is enabled

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
-        if: ${{ inputs.push }} == false
+        if: ${{ inputs.push }} == true
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
-        if: ${{ inputs.push }} == true
+        if: ${{ inputs.push == 'true' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
+        if: ${{ inputs.push }} == false
         uses: docker/login-action@v2
         with:
           registry: ghcr.io


### PR DESCRIPTION
[Publish](https://github.com/flyteorg/flytetools/blob/master/.github/workflows/publish.yml) workflow will try to run docker login first. However, this task will fail if people create a pr from fork repo. 
Here is an [example](https://github.com/flyteorg/flyteconsole/pull/735).

Login to GitHub registry if needed.

I've tested here. https://github.com/flyteorg/flyteconsole/pull/735/commits/606d54ea1ea25fb75f78edf2d912f21b7961f553